### PR TITLE
Fix JPQL query, correct JDBC URL, and add BookRestController with GET /books endpoint

### DIFF
--- a/src/main/java/np/com/krishnabk/librarycrud/dao/BookDAOJpaImpl.java
+++ b/src/main/java/np/com/krishnabk/librarycrud/dao/BookDAOJpaImpl.java
@@ -24,7 +24,7 @@ public class BookDAOJpaImpl implements BookDAO {
     public List<Book> findAll() {
 
         // create query
-        TypedQuery<Book> theQuery = entityManager.createQuery("select Book", Book.class);
+        TypedQuery<Book> theQuery = entityManager.createQuery("from Book", Book.class);
 
         // execute query and get result list
         List<Book> bookList = theQuery.getResultList();

--- a/src/main/java/np/com/krishnabk/librarycrud/rest/BookRestController.java
+++ b/src/main/java/np/com/krishnabk/librarycrud/rest/BookRestController.java
@@ -1,0 +1,29 @@
+package np.com.krishnabk.librarycrud.rest;
+
+import np.com.krishnabk.librarycrud.dao.BookDAO;
+import np.com.krishnabk.librarycrud.entity.Book;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/")
+public class BookRestController {
+
+    private BookDAO bookDAO;
+
+    // quick and dirty: inject book dao to use constructor injection (will add service layer later)
+    @Autowired
+    public BookRestController(BookDAO theBookDAO){
+        bookDAO = theBookDAO;
+    }
+
+    // expose "/books" and return a list books
+    @GetMapping("/books")
+    public List<Book> findAll(){
+        return bookDAO.findAll();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=BookStore
 
-spring.datasource.url=jdbc:mysql://localhost::3306/book_store
+spring.datasource.url=jdbc:mysql://localhost:3306/book_store
 spring.datasource.username=springstudent
 spring.datasource.password=springstudent


### PR DESCRIPTION
This PR includes the following improvements:

* Fixed the JPQL query in `BookDAOJpaImpl` from `"select Book"` to `"from Book"` for correct entity retrieval
* Corrected the JDBC URL typo in `application.properties` removing double colon (`::`)
* Added `BookRestController` exposing `/api/v1/books` GET endpoint to return a list of books

These changes improve database query correctness and add REST API functionality for books.